### PR TITLE
More options for how to handle duplicate barcode sequences.

### DIFF
--- a/include/kaori/SimpleSingleMatch.hpp
+++ b/include/kaori/SimpleSingleMatch.hpp
@@ -38,9 +38,17 @@ public:
      * @param search_reverse Should the search be performed on the reverse strand of the read sequence?
      * @param barcode_pool Known sequences for the single variable region in `template_seq`.
      * @param max_mismatches Maximum number of mismatches to consider across the entire template sequence.
-     * @param duplicates Whether duplicate sequences are allowed in `barcode_pool`, see `MismatchTrie`.
+     * @param duplicates How duplicate sequences in `barcode_pool` should be handled.
      */
-    SimpleSingleMatch(const char* template_seq, size_t template_length, bool search_forward, bool search_reverse, const BarcodePool& barcode_pool, int max_mismatches = 0, bool duplicates = false) : 
+    SimpleSingleMatch(
+        const char* template_seq, 
+        size_t template_length, 
+        bool search_forward, 
+        bool search_reverse, 
+        const BarcodePool& barcode_pool, 
+        int max_mismatches = 0, 
+        DuplicateAction duplicates = DuplicateAction::ERROR
+    ) : 
         num_options(barcode_pool.pool.size()),
         forward(search_forward), 
         reverse(search_reverse),

--- a/include/kaori/handlers/CombinatorialBarcodesPairedEnd.hpp
+++ b/include/kaori/handlers/CombinatorialBarcodesPairedEnd.hpp
@@ -46,13 +46,13 @@ public:
      * @param random Whether the reads are randomized with respect to the first/second target sequences.
      * If `false`, the first read is searched for the first template only, and the second read is searched for the second template only.
      * If `true`, an additional search will be performed in the opposite orientation.
-     * @param duplicates Whether to allow duplicates in `barcode_pool1` and `barcode_pool2`, see `MismatchTrie` for details.
+     * @param duplicates How duplicates in `barcode_pool1` and `barcode_pool2` should be handled.
      */
     CombinatorialBarcodesPairedEnd(
         const char* template_seq1, size_t template_length1, bool reverse1, const BarcodePool& barcode_pool1, int max_mismatches1, 
         const char* template_seq2, size_t template_length2, bool reverse2, const BarcodePool& barcode_pool2, int max_mismatches2,
         bool random = false,
-        bool duplicates = false
+        DuplicateAction duplicates = DuplicateAction::ERROR
     ) :
         matcher1(template_seq1, template_length1, !reverse1, reverse1, barcode_pool1, max_mismatches1, duplicates),
         matcher2(template_seq2, template_length2, !reverse2, reverse2, barcode_pool2, max_mismatches2, duplicates),

--- a/include/kaori/handlers/DualBarcodesWithDiagnostics.hpp
+++ b/include/kaori/handlers/DualBarcodesWithDiagnostics.hpp
@@ -55,7 +55,7 @@ public:
         dual_handler(template_seq1, template_length1, reverse1, barcode_pool1, max_mismatches1, template_seq2, template_length2, reverse2, barcode_pool2, max_mismatches2, random),
 
         // we allow duplicates in the trie.
-        combo_handler(template_seq1, template_length1, reverse1, barcode_pool1, max_mismatches1, template_seq2, template_length2, reverse2, barcode_pool2, max_mismatches2, random, true) 
+        combo_handler(template_seq1, template_length1, reverse1, barcode_pool1, max_mismatches1, template_seq2, template_length2, reverse2, barcode_pool2, max_mismatches2, random, DuplicateAction::FIRST) 
     {}
 
     /**

--- a/include/kaori/utils.hpp
+++ b/include/kaori/utils.hpp
@@ -5,8 +5,26 @@
 #include <vector>
 #include <array>
 
-namespace {
+/**
+ * @file utils.hpp
+ * @brief Utilites for sequence matching.
+ */
 
+namespace kaori {
+
+/**
+ * How to deal with duplicated sequences in the pool of known barcodes.
+ *
+ * - `FIRST`: keep the first encountered instance of a set of duplicates.
+ * - `LAST`: keep the last encountered instance of a set of duplicates.
+ * - `NONE`: do not keep any duplicate sequences.
+ * - `ERROR`: throw an error upon observing a duplicate sequence.
+ */
+enum class DuplicateAction : char { FIRST, LAST, NONE, ERROR };
+
+/**
+ * @cond
+ */
 template<bool allow_n_ = false, bool allow_iupac_ = false>
 char complement_base(char b) {
     char output;
@@ -165,6 +183,9 @@ void sort_combinations(std::vector<std::array<int, V> >& combinations, const std
         combinations.swap(copy);
     }
 }
+/**
+ * @endcond
+ */
 
 }
 


### PR DESCRIPTION
In particular, duplicate assignments can now be ignored, rather than just erroring out or taking the first occurence. This is a convenient option for simple barcodes (the same effect could be achieved by more careful user input), but it becomes particularly useful for barcodes containing ambiguous codes where the user doesn't want to realize all possibilities for pruning.